### PR TITLE
Fixed Markup import. Modified get_partial() function which failed on some HTML

### DIFF
--- a/examples/bootstrap4/requirements.txt
+++ b/examples/bootstrap4/requirements.txt
@@ -1,6 +1,6 @@
 Flask
 Flask-Modals
-Bootstrap-Flask==1.5.2
-Flask-Login==0.5.0
-Flask-WTF==0.14.3
-email-validator==1.1.2
+Bootstrap-Flask
+Flask-Login
+Flask-WTF
+email-validator

--- a/examples/bootstrap5/requirements.txt
+++ b/examples/bootstrap5/requirements.txt
@@ -1,4 +1,4 @@
 Flask
 Flask-Modals
-Flask-WTF==0.14.3
-email-validator==1.1.2
+Flask-WTF
+email-validator

--- a/flask_modals/modal.py
+++ b/flask_modals/modal.py
@@ -2,7 +2,7 @@ from functools import wraps
 
 from flask import (Blueprint, render_template, get_flashed_messages,
                    _app_ctx_stack, request)
-from jinja2.utils import markupsafe
+from markupsafe import Markup
 from flask_modals.partial import get_partial
 
 
@@ -10,7 +10,7 @@ def modal_messages():
     '''This will be available in the app templates for use in the modal
     body.
     '''
-    return markupsafe.Markup(render_template('modals/modalMessages.html'))
+    return Markup(render_template('modals/modalMessages.html'))
 
 
 def render_template_modal(*args, **kwargs):

--- a/flask_modals/partial.py
+++ b/flask_modals/partial.py
@@ -9,7 +9,7 @@ def get_partial(modal_id, *args, **kwargs):
     root_node = html.fromstring(doc)
     xpath = f'//div[@id="{modal_id}"]'      # modal window
     modal_node = root_node.xpath(xpath)[0]
-    xpath = '//div[@class="modal-body"]'    # modal body
+    xpath = './/div[@class="modal-body"]'    # modal body
     body_node = modal_node.xpath(xpath)[0]
     body = str(etree.tostring(body_node)).replace('\\n', '').replace('\n', '')
     return body

--- a/flask_modals/partial.py
+++ b/flask_modals/partial.py
@@ -1,29 +1,15 @@
-import re
-
+from lxml import etree, html
 from flask import render_template
 
 
-def get_partial(modal, *args, **kwargs):
+def get_partial(modal_id, *args, **kwargs):
     '''Return the modal body.'''
 
-    html = render_template(*args, **kwargs)
-    lines = html.splitlines(keepends=True)
-
-    found_modal = False
-    found_modal_body = False
-    div_count = 0
-    partial = ''
-    for line in lines:
-        if f'id="{modal}"' in line:
-            found_modal = True
-        if found_modal:
-            if 'class="modal-body' in line:
-                found_modal_body = True
-            if found_modal_body:
-                partial += line
-                startdivs = re.findall(r'<div.*?>', line, re.IGNORECASE)
-                enddivs = re.findall(r'</div>', line, re.IGNORECASE)
-                div_count += len(startdivs) - len(enddivs)
-                if div_count <= 0:
-                    break
-    return partial
+    doc = render_template(*args, **kwargs)
+    root_node = html.fromstring(doc)
+    xpath = f'//div[@id="{modal_id}"]'      # modal window
+    modal_node = root_node.xpath(xpath)[0]
+    xpath = '//div[@class="modal-body"]'    # modal body
+    body_node = modal_node.xpath(xpath)[0]
+    body = str(etree.tostring(body_node)).replace('\\n', '').replace('\n', '')
+    return body

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setuptools.setup(
                                    'static/js/main.js',
                                    'static/css/progressBarStyle.css']},
     include_package_data=True,
-    install_requires=['Flask'],
+    install_requires=['Flask', 'lxml'],
     zip_safe=False,
     classifiers=[
         'Development Status :: 3 - Alpha',


### PR DESCRIPTION
- Fixed Markup import. 
- Modified get_partial() function (now relying on lxml) which failed parsing some pieces of HTML (didn't locate the modal body giving a partial that started at beginning of modal window until the end of the html document; ie. </html>). 
- Added lxml as required dependency in setup.py. 
- Removed any version constraint in requirements.txt of the examples.
­
Feel free to review at your convenience.